### PR TITLE
Add support for Gitlab manual status

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Actually only used by the html endpoint.
 ## prometheus
 Endpoint: `/api/adapter/prometheus`
 
-Can be used as exporter from a prometheus scraper. Return values are: success=0, skipped=1, canceled=2, failed=10. 
+Can be used as exporter from a prometheus scraper. Return values are: success=0, skipped=1, canceled=2, manual=3, failed=10. 
 
 Examples:
 

--- a/src/main/java/de/joblift/service/gitlabpanorama/core/models/Status.java
+++ b/src/main/java/de/joblift/service/gitlabpanorama/core/models/Status.java
@@ -11,6 +11,7 @@ public enum Status {
 
 	// sleeping
 	success,
+	manual,
 	failed,
 	canceled,
 	skipped;

--- a/src/main/java/de/joblift/service/gitlabpanorama/resources/adapter/bashboard/ShellResource.java
+++ b/src/main/java/de/joblift/service/gitlabpanorama/resources/adapter/bashboard/ShellResource.java
@@ -61,7 +61,8 @@ public class ShellResource {
 			String stringFailures = list(pipelines, Status.failed, delimiterProjects, refs, filterStatusList);
 			String stringSkipped = list(pipelines, Status.skipped, delimiterProjects, refs, filterStatusList);
 			String stringSuccess = list(pipelines, Status.success, delimiterProjects, refs, filterStatusList);
-			builder.append(Joiner.on(delimiterLists).skipNulls().join(stringFailures, stringSkipped, stringSuccess));
+			String stringManual = list(pipelines, Status.manual, delimiterProjects, refs, filterStatusList);
+			builder.append(Joiner.on(delimiterLists).skipNulls().join(stringFailures, stringSkipped, stringSuccess, stringManual));
 		}
 		return builder.toString();
 
@@ -99,6 +100,9 @@ public class ShellResource {
 		}
 		if (pair.getCurrent().getStatus() == Status.skipped) {
 			return Color.WHITE;
+		}
+		if (pair.getCurrent().getStatus() == Status.manual) {
+			return Color.CYAN;
 		}
 		return Color.MAGENTA;
 	}

--- a/src/main/java/de/joblift/service/gitlabpanorama/resources/adapter/ccmenu/CcmenuResource.java
+++ b/src/main/java/de/joblift/service/gitlabpanorama/resources/adapter/ccmenu/CcmenuResource.java
@@ -98,8 +98,11 @@ public class CcmenuResource {
 		if (pair.getCurrent().getStatus() == Status.failed) {
 			return "Failure";
 		}
-		// ccmenu does not reflect skipped, show as success since it is at least not failed
+		// ccmenu does not reflect skipped or manual, show as success since it is at least not failed
 		if (pair.getCurrent().getStatus() == Status.skipped) {
+			return "Success";
+		}
+		if (pair.getCurrent().getStatus() == Status.manual) {
 			return "Success";
 		}
 		return "Unknown";

--- a/src/main/java/de/joblift/service/gitlabpanorama/resources/adapter/prometheus/PrometheusExporter.java
+++ b/src/main/java/de/joblift/service/gitlabpanorama/resources/adapter/prometheus/PrometheusExporter.java
@@ -43,6 +43,8 @@ public class PrometheusExporter {
 				return "1";
 			case canceled:
 				return "2";
+			case manual:
+				return "3";
 			case failed:
 				return "10";
 			default:

--- a/src/test/java/de/joblift/service/gitlabpanorama/core/aggregator/PipelinePairTest.java
+++ b/src/test/java/de/joblift/service/gitlabpanorama/core/aggregator/PipelinePairTest.java
@@ -1,15 +1,14 @@
 package de.joblift.service.gitlabpanorama.core.aggregator;
 
-import static de.galan.commons.time.Instants.*;
-import static org.assertj.core.api.Assertions.*;
-
-import java.time.Instant;
-
-import org.junit.jupiter.api.Test;
-
 import de.joblift.service.gitlabpanorama.core.models.Pipeline;
 import de.joblift.service.gitlabpanorama.core.models.Project;
 import de.joblift.service.gitlabpanorama.core.models.Status;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static de.galan.commons.time.Instants.instantUtc;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**
@@ -47,6 +46,14 @@ public class PipelinePairTest {
 		PipelinePair pp = new PipelinePair(pa, pc);
 		assertThat(pp.getActive()).isEqualTo(pa);
 		assertThat(pp.getCurrent()).isEqualTo(pc);
+	}
+
+	@Test
+	public void singleManual() {
+		Pipeline p = p(1L, Status.manual);
+		PipelinePair pp = new PipelinePair(p);
+		assertThat(pp.getActive()).isNull();
+		assertThat(pp.getCurrent()).isEqualTo(p);
 	}
 
 
@@ -102,6 +109,15 @@ public class PipelinePairTest {
 		PipelinePair pp = new PipelinePair(pc1, pa, pc2);
 		assertThat(pp.getActive()).isNull();
 		assertThat(pp.getCurrent()).isEqualTo(pc2);
+	}
+
+	@Test
+	public void currentActiveFromManual() {
+		Pipeline pc = p(1L, Status.manual, T1);
+		Pipeline pa = p(1L, Status.running, T2);
+		PipelinePair pp = new PipelinePair(pa, pc);
+		assertThat(pp.getActive()).isEqualTo(pa);
+		assertThat(pp.getCurrent()).isEqualTo(pc);
 	}
 
 


### PR DESCRIPTION
Gitlab pipelines also has a manual status for some projects which are utilised to control deployments. Adding in support for this. Tests may not be that great as I got a little confused by states being tested and since this is a bit like a success can sort of be classified that way. Would be open to further discussion.